### PR TITLE
Refactor integers-test to use juxt

### DIFF
--- a/test/unit/nedap/utils/spec/predicates.cljc
+++ b/test/unit/nedap/utils/spec/predicates.cljc
@@ -6,48 +6,43 @@
    [spec-coerce.core :as spec-coerce]))
 
 (deftest integers
-  #?(:clj (are [v
-                f ef
-                g eg
-                h eh] (do
-                        (is (= ef (f v)))
-                        (is (= eg (g v)))
-                        (is (= eh (h v))))
-            nil                               sut/neg-integer? false sut/nat-integer? false sut/pos-integer? false
-            ""                                sut/neg-integer? false sut/nat-integer? false sut/pos-integer? false
-            []                                sut/neg-integer? false sut/nat-integer? false sut/pos-integer? false
-            Double/MIN_VALUE                  sut/neg-integer? false sut/nat-integer? false sut/pos-integer? false
-            Double/MAX_VALUE                  sut/neg-integer? false sut/nat-integer? false sut/pos-integer? false
-            -1.0                              sut/neg-integer? false sut/nat-integer? false sut/pos-integer? false
-            0.0                               sut/neg-integer? false sut/nat-integer? false sut/pos-integer? false
-            1.0                               sut/neg-integer? false sut/nat-integer? false sut/pos-integer? false
+  #?(:clj (are [v expected] (= expected
+                               ((juxt sut/neg-integer? sut/nat-integer? sut/pos-integer?) v))
+            nil                               [false false false]
+            ""                                [false false false]
+            []                                [false false false]
+            Double/MIN_VALUE                  [false false false]
+            Double/MAX_VALUE                  [false false false]
+            -1.0                              [false false false]
+            0.0                               [false false false]
+            1.0                               [false false false]
 
-            -1                                sut/neg-integer? true  sut/nat-integer? false sut/pos-integer? false
+            -1                                [true  false false]
 
-            0                                 sut/neg-integer? false sut/nat-integer? true  sut/pos-integer? false
+            0                                 [false true  false]
 
-            1                                 sut/neg-integer? false sut/nat-integer? true  sut/pos-integer? true
+            1                                 [false true  true]
 
-            (Integer. -1)                     sut/neg-integer? true  sut/nat-integer? false sut/pos-integer? false
-            (Long. -1)                        sut/neg-integer? true  sut/nat-integer? false sut/pos-integer? false
-            (clojure.lang.BigInt/fromLong -1) sut/neg-integer? true  sut/nat-integer? false sut/pos-integer? false
-            (BigInteger/valueOf -1)           sut/neg-integer? true  sut/nat-integer? false sut/pos-integer? false
-            (Short. "-1")                     sut/neg-integer? true  sut/nat-integer? false sut/pos-integer? false
-            (Long. -1)                        sut/neg-integer? true  sut/nat-integer? false sut/pos-integer? false
+            (Integer. -1)                     [true  false false]
+            (Long. -1)                        [true  false false]
+            (clojure.lang.BigInt/fromLong -1) [true  false false]
+            (BigInteger/valueOf -1)           [true  false false]
+            (Short. "-1")                     [true  false false]
+            (Long. -1)                        [true  false false]
 
-            (Integer. 0)                      sut/neg-integer? false sut/nat-integer? true  sut/pos-integer? false
-            (Long. 0)                         sut/neg-integer? false sut/nat-integer? true  sut/pos-integer? false
-            (clojure.lang.BigInt/fromLong 0)  sut/neg-integer? false sut/nat-integer? true  sut/pos-integer? false
-            (BigInteger/valueOf 0)            sut/neg-integer? false sut/nat-integer? true  sut/pos-integer? false
-            (Short. "0")                      sut/neg-integer? false sut/nat-integer? true  sut/pos-integer? false
-            (Long. 0)                         sut/neg-integer? false sut/nat-integer? true  sut/pos-integer? false
+            (Integer. 0)                      [false true  false]
+            (Long. 0)                         [false true  false]
+            (clojure.lang.BigInt/fromLong 0)  [false true  false]
+            (BigInteger/valueOf 0)            [false true  false]
+            (Short. "0")                      [false true  false]
+            (Long. 0)                         [false true  false]
 
-            (Integer. 1)                      sut/neg-integer? false sut/nat-integer? true  sut/pos-integer? true
-            (Long. 1)                         sut/neg-integer? false sut/nat-integer? true  sut/pos-integer? true
-            (clojure.lang.BigInt/fromLong 1)  sut/neg-integer? false sut/nat-integer? true  sut/pos-integer? true
-            (BigInteger/valueOf 1)            sut/neg-integer? false sut/nat-integer? true  sut/pos-integer? true
-            (Short. "1")                      sut/neg-integer? false sut/nat-integer? true  sut/pos-integer? true
-            (Long. 1)                         sut/neg-integer? false sut/nat-integer? true  sut/pos-integer? true)))
+            (Integer. 1)                      [false true  true]
+            (Long. 1)                         [false true  true]
+            (clojure.lang.BigInt/fromLong 1)  [false true  true]
+            (BigInteger/valueOf 1)            [false true  true]
+            (Short. "1")                      [false true  true]
+            (Long. 1)                         [false true  true])))
 
 (deftest named?
   (are [x expectation] (= expectation


### PR DESCRIPTION
## Brief

de-duplicates examples, improves error reporting a bit, 

consistent with the test in #12 

minor side effect; Using `is` inside an `are` messes up the total count (e.g. every `are`-clause is counted as 1, plus 3 `is` statements in this case).


<!-- Which issue does this PR fix? Ideally, create an issue if there was none, so the problem in question is well stated. -->

## QA plan

none

<!-- Please state a reproducible plan to prove this PR works. Attach screenshots, gifs, etc. if needed. Occasionally, sufficient test coverage removes the need for QAing. -->

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [x] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
