### PR TITLE
relax dependency on spec-coerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Selected, generic predicates that you might find handy when specing things.
 ## Installation
 
 ```clojure
-[com.nedap.staffing-solutions/utils.spec.predicates "1.2.1"]
+[com.nedap.staffing-solutions/utils.spec.predicates "1.2.2-alpha1"]
 ```
 
 ## Documentation

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 ;; Please don't bump the library version by hand - use ci.release-workflow instead.
-(defproject com.nedap.staffing-solutions/utils.spec.predicates "1.2.1"
+(defproject com.nedap.staffing-solutions/utils.spec.predicates "1.2.2-alpha1"
   ;; Please keep the dependencies sorted a-z.
   :dependencies [[com.nedap.staffing-solutions/speced.def "1.1.1"]
                  [org.clojure/clojure "1.10.1"]]

--- a/src/nedap/utils/spec/predicates.cljc
+++ b/src/nedap/utils/spec/predicates.cljc
@@ -4,8 +4,8 @@
    [clojure.spec.gen.alpha :as gen]
    [clojure.string :as string]
    [nedap.speced.def :as speced]
-   [nedap.utils.spec.predicates.impl :as impl]
-   [spec-coerce.core :as spec-coerce])
+   [nedap.utils.spec.predicates.impl :as impl :refer [when-spec-coerce-available?]])
+  #?(:cljs (:require-macros [nedap.utils.spec.predicates.impl :refer [when-spec-coerce-available?]]))
   #?(:clj (:import (java.time LocalDate LocalDateTime Instant ZonedDateTime OffsetDateTime Duration OffsetTime LocalTime ZoneId))))
 
 (speced/defn ^boolean? neg-integer?
@@ -86,11 +86,12 @@
 
 (def pos-integer-coercer (impl/coercer pos-integer?))
 
-(defmethod spec-coerce/sym->coercer `neg-integer? [_] neg-integer-coercer)
+(when-spec-coerce-available?
+ (defmethod spec-coerce.core/sym->coercer `neg-integer? [_] neg-integer-coercer)
 
-(defmethod spec-coerce/sym->coercer `nat-integer? [_] nat-integer-coercer)
+ (defmethod spec-coerce.core/sym->coercer `nat-integer? [_] nat-integer-coercer)
 
-(defmethod spec-coerce/sym->coercer `pos-integer? [_] pos-integer-coercer)
+ (defmethod spec-coerce.core/sym->coercer `pos-integer? [_] pos-integer-coercer))
 
 (spec/def ::neg-integer
   (-> neg-integer?

--- a/src/nedap/utils/spec/predicates/impl.cljc
+++ b/src/nedap/utils/spec/predicates/impl.cljc
@@ -27,3 +27,11 @@
                                        x))
                                    (catch js/Error _
                                      x))))))
+
+(defmacro when-spec-coerce-available? [& body]
+  (when (try
+          (requiring-resolve 'spec-coerce.core/sym->coercer)
+          true
+          (catch Exception _
+            false))
+    `(do ~@body)))


### PR DESCRIPTION
## Brief

spec-coerce.core may not be on the classpath (not a defined dependency of utils.spec.predicates, rather an accidental transient dependency).

We can either declare `spec-coerce` a dependency, or relax the requirement. I chose the latter.

<!-- Which issue does this PR fix? Ideally, create an issue if there was none, so the problem in question is well stated. -->

## QA plan

<!-- Please state a reproducible plan to prove this PR works. Attach screenshots, gifs, etc. if needed. Occasionally, sufficient test coverage removes the need for QAing. -->

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [ ] I have QAed the functionality
* [ ] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [ ] The build passes
* [ ] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
